### PR TITLE
Make re-export of re-exported variant hideable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,7 @@ pub fn phantom(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         mod #value_namespace {
+            #[doc(hidden)]
             #vis_super use super::#ident::#ident;
         }
 


### PR DESCRIPTION
Without this, the second approach shown in https://github.com/dtolnay/ghost/tree/0.1.15#Documentation does not work. Rustdoc ignores the #\[doc(hidden)\] on the re-export. (Past versions of rustdoc did not used to ignore it.)