### PR TITLE
Support phantom types inside a method body

### DIFF
--- a/tests/function-body.rs
+++ b/tests/function-body.rs
@@ -1,0 +1,6 @@
+use ghost::phantom;
+
+const fn main() {
+    #[phantom]
+    struct MyPhantom<T: ?Sized>;
+}

--- a/tests/ui/autotraits.stderr
+++ b/tests/ui/autotraits.stderr
@@ -15,7 +15,7 @@ note: required because it appears within the type `__void_MyPhantom::MyPhantom<*
    |
  4 | struct MyPhantom<T: ?Sized>;
    |        ^^^^^^^^^
-note: required because it appears within the type `MyPhantom<*const u8>`
+note: required because it appears within the type `MyPhantom__Phantom<*const u8>`
   --> tests/ui/autotraits.rs:4:8
    |
  4 | struct MyPhantom<T: ?Sized>;
@@ -44,7 +44,7 @@ note: required because it appears within the type `__void_MyPhantom::MyPhantom<*
    |
  4 | struct MyPhantom<T: ?Sized>;
    |        ^^^^^^^^^
-note: required because it appears within the type `MyPhantom<*const u8>`
+note: required because it appears within the type `MyPhantom__Phantom<*const u8>`
   --> tests/ui/autotraits.rs:4:8
    |
  4 | struct MyPhantom<T: ?Sized>;

--- a/tests/ui/ffi.stderr
+++ b/tests/ui/ffi.stderr
@@ -1,4 +1,4 @@
-error: `extern` fn uses type `MyPhantom<i32>`, which is not FFI-safe
+error: `extern` fn uses type `MyPhantom__Phantom<i32>`, which is not FFI-safe
  --> tests/ui/ffi.rs:8:39
   |
 8 | pub extern "C" fn extern_fn(_phantom: MyPhantom<i32>) {}

--- a/tests/ui/function-body.rs
+++ b/tests/ui/function-body.rs
@@ -1,8 +1,0 @@
-use ghost::phantom;
-
-fn main() {
-    // Not supported. https://github.com/dtolnay/ghost/issues/1
-
-    #[phantom]
-    struct MyPhantom<T: ?Sized>;
-}

--- a/tests/ui/invariant.stderr
+++ b/tests/ui/invariant.stderr
@@ -6,8 +6,8 @@ error: lifetime may not live long enough
 7 |     phantom
   |     ^^^^^^^ returning this value requires that `'a` must outlive `'static`
   |
-  = note: requirement occurs because of the type `InvariantPhantom<&str>`, which makes the generic argument `&str` invariant
-  = note: the enum `InvariantPhantom<T>` is invariant over the parameter `T`
+  = note: requirement occurs because of the type `InvariantPhantom__Phantom<&str>`, which makes the generic argument `&str` invariant
+  = note: the enum `InvariantPhantom__Phantom<T>` is invariant over the parameter `T`
   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -18,6 +18,6 @@ error: lifetime may not live long enough
 11 |     phantom
    |     ^^^^^^^ returning this value requires that `'a` must outlive `'static`
    |
-   = note: requirement occurs because of the type `InvariantPhantom<&str>`, which makes the generic argument `&str` invariant
-   = note: the enum `InvariantPhantom<T>` is invariant over the parameter `T`
+   = note: requirement occurs because of the type `InvariantPhantom__Phantom<&str>`, which makes the generic argument `&str` invariant
+   = note: the enum `InvariantPhantom__Phantom<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tests/ui/pattern-match.stderr
+++ b/tests/ui/pattern-match.stderr
@@ -1,39 +1,39 @@
-error[E0004]: non-exhaustive patterns: `MyPhantom::__Phantom(_)` not covered
+error[E0004]: non-exhaustive patterns: `MyPhantom__Phantom::__Phantom(_)` not covered
  --> tests/ui/pattern-match.rs:9:11
   |
 9 |     match phantom {
-  |           ^^^^^^^ pattern `MyPhantom::__Phantom(_)` not covered
+  |           ^^^^^^^ pattern `MyPhantom__Phantom::__Phantom(_)` not covered
   |
-note: `MyPhantom<u8>` defined here
+note: `MyPhantom__Phantom<u8>` defined here
  --> tests/ui/pattern-match.rs:4:8
   |
 3 | #[phantom]
   | ---------- not covered
 4 | struct MyPhantom<T: ?Sized>;
   |        ^^^^^^^^^
-  = note: the matched value is of type `MyPhantom<u8>`
+  = note: the matched value is of type `MyPhantom__Phantom<u8>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
   |
 10~         MyPhantom => {},
-11+         MyPhantom::__Phantom(_) => todo!()
+11+         MyPhantom__Phantom::__Phantom(_) => todo!()
   |
 
-error[E0004]: non-exhaustive patterns: `MyPhantom::__Phantom(_)` not covered
+error[E0004]: non-exhaustive patterns: `MyPhantom__Phantom::__Phantom(_)` not covered
   --> tests/ui/pattern-match.rs:13:11
    |
 13 |     match phantom {
-   |           ^^^^^^^ pattern `MyPhantom::__Phantom(_)` not covered
+   |           ^^^^^^^ pattern `MyPhantom__Phantom::__Phantom(_)` not covered
    |
-note: `MyPhantom<u8>` defined here
+note: `MyPhantom__Phantom<u8>` defined here
   --> tests/ui/pattern-match.rs:4:8
    |
  3 | #[phantom]
    | ---------- not covered
  4 | struct MyPhantom<T: ?Sized>;
    |        ^^^^^^^^^
-   = note: the matched value is of type `MyPhantom<u8>`
+   = note: the matched value is of type `MyPhantom__Phantom<u8>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 14 ~         MyPhantom::<u8> => {},
-15 +         MyPhantom::__Phantom(_) => todo!()
+15 +         MyPhantom__Phantom::__Phantom(_) => todo!()
    |


### PR DESCRIPTION
Fixes #1.

Notes: the name in type hints is different; error reports are different; docs are rendered differently. Due to that, I wouldn't be surprised if you don't approve these changes. However, I don't want to just throw this code away; it might be useful for a full, non-breaking fix.

Before | After
--:|:--
<img width="435" height="72" alt="image" src="https://github.com/user-attachments/assets/d035b29e-0b69-40e9-94e2-38420e201dd9" /> | <img width="512" height="74" alt="image" src="https://github.com/user-attachments/assets/d07e42ef-8337-4c42-9c27-b8be54240672" />
<img width="333" height="201" alt="image" src="https://github.com/user-attachments/assets/8479de37-2c97-4a6c-a2e6-05ec9f8f8a32" /> | <img width="331" height="209" alt="image" src="https://github.com/user-attachments/assets/ae1e6e30-d96b-48f5-a372-e2e8d0a55e3c" />
<img width="1003" height="1303" alt="image" src="https://github.com/user-attachments/assets/81c3873d-99d4-4bd8-b1c7-9375853da239" /> | <img width="516" height="472" alt="image" src="https://github.com/user-attachments/assets/f3c1f2df-8934-417a-9f52-2658f2996273" />
