### PR TITLE
`#[repr(Rust, packed)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,7 @@ pub fn phantom(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             }
 
-            #[repr(packed)]
+            #[repr(Rust, packed)]
             struct #type_param<T: ?::core::marker::Sized>([*const T; 0]);
             #[automatically_derived]
             impl<T: ?::core::marker::Sized> ::core::marker::Copy for #type_param<T> {}


### PR DESCRIPTION
Changes in #42 seem to warn with `clippy::repr_packed_without_abi` (encountered on Rust 1.95, the lint seems to have been there since 1.85). ~~#42 had its `clippy` check skipped~~ nvm, wouldn't matter, it's not checking the doc/usage example code if I understand correctly?

`#[repr(transparent)]` still works, from what I've seen (tested with #41 code).
