### PR TITLE
Resolve repr_packed_without_abi clippy lint 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.85.0, 1.71.0]
+        rust: [nightly, beta, stable, 1.85.0, 1.74.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
@@ -35,7 +35,7 @@ jobs:
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
         if: matrix.rust == 'nightly'
       - run: cargo test
-        if: matrix.rust != '1.71.0'
+        if: matrix.rust != '1.74.0'
       - run: cargo doc --package ghost-test-doc
       - uses: actions/upload-artifact@v7
         if: matrix.rust == 'nightly' && always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@clippy
-      - run: cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic
+      - run: cargo clippy --workspace --tests -- -Dclippy::all -Dclippy::pedantic
 
   outdated:
     name: Outdated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/ghost"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/ghost"
-rust-version = "1.71"
+rust-version = "1.74"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,7 @@ pub fn phantom(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             }
 
-            #[repr(packed)]
+            #[repr(Rust, packed)]
             struct #type_param<T: ?::core::marker::Sized>([*const T; 0]);
             #[automatically_derived]
             impl<T: ?::core::marker::Sized> ::core::marker::Copy for #type_param<T> {}


### PR DESCRIPTION
```console
warning: item uses `packed` representation without ABI-qualification
 --> tests/doc/src/lib.rs:3:1
  |
3 | #[phantom]
  | ^^^^^^^^^^ `packed` representation set here
  |
  = warning: unqualified `#[repr(packed)]` defaults to `#[repr(Rust, packed)]`, which has no stable ABI
  = help: qualify the desired ABI explicitly via `#[repr(C, packed)]` or `#[repr(Rust, packed)]`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#repr_packed_without_abi
  = note: `#[warn(clippy::repr_packed_without_abi)]` on by default
  = note: this warning originates in the attribute macro `phantom` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Closes #44.